### PR TITLE
Fix type retrieval and error messaging

### DIFF
--- a/src/genDDL.ts
+++ b/src/genDDL.ts
@@ -16,7 +16,7 @@ function toSqlType(rdtType: RDTTypeDef): string {
         return "BOOLEAN";
     }
 
-    throw new Error(`Unknown RDTTypeDef type: ${debugRDTType}`);
+    throw new Error(`Unknown RDTTypeDef type: ${debugRDTType(rdtType)}`);
 }
 
 const operatorMap : Record<RDTMath["operator"], string> = {

--- a/src/invert.ts
+++ b/src/invert.ts
@@ -194,7 +194,7 @@ export function walkReduce(reduceFunction: RDTFunction, ctx: { reduceIntent: RDT
     if (reduceFunction.parameters.length !== 2) throw new Error(`Expected two parameters for reduce function, got: ${reduceFunction.parameters.length}`);
     const [accParameter, rowParameter] = reduceFunction.parameters;
     const accParameterType = getTypeMetadata(accParameter, { returnRawBinding: false });
-    const rowParameterType = getTypeMetadata(accParameter, { returnRawBinding: false });
+    const rowParameterType = getTypeMetadata(rowParameter, { returnRawBinding: false });
     if (!accParameterType || accParameterType.type === "RDTTypeUnknown") throw new Error(`Accumulator type is unknown in reducer`);
     if (!rowParameterType || rowParameterType.type === "RDTTypeUnknown") throw new Error(`Row type is uknown in reducer`);
 


### PR DESCRIPTION
## Summary
- correct parameter used for `rowParameterType` in `walkReduce`
- include missing argument in `toSqlType` error message

## Testing
- `npm run tsc` *(fails: Cannot find module 'node:fs' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6866a2b7b4bc833193bae98b48864890