### PR TITLE
Fix README SQL expressions line

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run gen && clear && npm run clean && npm run start src/index2.ts e4.dml 6
 
 Manually run DDL Changes (`out/ddl.sql`) against postgres database.
 
-You can then run some SQL expresions to test the output:
+You can then run some SQL expressions to test the output
 ```sql
 truncate "BankAccount";
 truncate "Transaction";


### PR DESCRIPTION
## Summary
- fix typo in README about running SQL expressions to test the output

## Testing
- `sed -n '22,26p' README.md`

------
https://chatgpt.com/codex/tasks/task_e_6866a5221788833189854c8259d1b171