### PR TITLE
Fix typo in processFilterPipeline error

### DIFF
--- a/src/genDDL.ts
+++ b/src/genDDL.ts
@@ -35,7 +35,7 @@ const operatorMap : Record<RDTMath["operator"], string> = {
 function processFilterPipeline(filter: RDTFilter, ctxRowIdentifier: string): (rowIdentifier: string) => string {
     return (rowIdentifier: string) => {
         const filterFunc = filter.condition;
-        if (filterFunc.parameters.length !== 1) throw new Error(`Invalid func definition, param lenght`);
+        if (filterFunc.parameters.length !== 1) throw new Error(`Invalid func definition, parameter length`);
         const triggerRowId = filterFunc.parameters[0].id;
         return walkDFS<RDTNode>(filterFunc.body, {
             // There is a problem if the column you are checking is a derived column and the derived column's type is different than the actual type.


### PR DESCRIPTION
## Summary
- fix typo in `processFilterPipeline` error message

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866a5249110833187f53af5992da9e5